### PR TITLE
spelling.patches

### DIFF
--- a/lib/Catmandu/Fix/lido_baseid.pm
+++ b/lib/Catmandu/Fix/lido_baseid.pm
@@ -72,7 +72,7 @@ The parameters C<path> and C<id_value> are mandatory paths.
 
 =head3 Optional parameters
 
-All optional parametes are strings.
+All optional parameters are strings.
 
 =over
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Catmandu-LIDO.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcatmandu-lido-perl/raw/master/debian/patches/spelling.patches

Thanks for considering,
  Mason James,
  Debian Perl Group
